### PR TITLE
Add GitHub Pages origin to CORS allowed origins

### DIFF
--- a/aci-tracker-backend/app/main.py
+++ b/aci-tracker-backend/app/main.py
@@ -9,7 +9,11 @@ app = FastAPI(title="ACI Deployment Tracker Backend", version="1.0.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],  # Add production URL later
+    allow_origins=[
+        "http://localhost:5173", 
+        "http://localhost:3000",
+        "https://ee-aadishbahati.github.io"
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
- Add https://ee-aadishbahati.github.io to CORS middleware allow_origins
- Fixes CORS policy error preventing GitHub Pages deployment from connecting to Fly.io backend
- Completes the GitHub Pages deployment fix alongside PR #34